### PR TITLE
Enforce type requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *build*
 *egg*
-
 pycache/* 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This changelog details all version bumps and changes made to the `flask_require` library.
 
+## [0.0.4]
+
+### 1. Update docs
+
+Docs are now using f strings instead of older style formatting.
+
+## 2. Add type enforcement
+
+Added type enforcement to the require.fields method.
+
 ## [0.0.3]
 
 ### 1. Improved the response function

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ app = Flask(__name__)
 @app.route('/')
 @require.fields(request)
 def index(name):
-    return 'Hello, %s!' % name
+    return f"Hello, {name}!"
 
 if __name__ == '__main__':
     app.run()
 ```
 
 ### fields with optional response_formatter
+
 ```python
 import flask
 import require
@@ -46,6 +47,26 @@ if __name__ == '__main__':
     app.run()
 ```
 
+### Enforcing types
+
+The system will check that the types provided in the signature and the types
+provided by the caller are the same before passing the arguments to the function.
+
+```python
+from flask import Flask,request
+import require
+
+app = Flask(__name__)
+
+@app.route('/')
+@require.fields(request)
+def index(name:str):
+    return f"Hello, {name}!"
+
+if __name__ == '__main__':
+    app.run()
+```
+
 ## Usage of admin
 
 ```python
@@ -57,7 +78,7 @@ app = Flask(__name__)
 @app.route('/')
 @fields(request)
 def index(name):
-    return 'Hello, %s!' % name
+    return f"Hello, {name}!"
 
 @app.route('/admin')
 @admin()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 authors = [{ name = "Ivar Jönsson", email = "ivajns-9@student.ltu.se" }]
 name = "flask_require"
-version = "0.0.3"
+version = "0.0.4"
 description = "A simple Flask extension for requiring parameters in a request."
 readme = "README.md"
 

--- a/require.py
+++ b/require.py
@@ -23,7 +23,7 @@ def fields(request, response_formatter=None, error_formatter=response):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # Get JSON data from request, if not pressent return 400
+            # Get JSON data from request, if not present return 400
             default_error_response = {
                 "name": "Invalid JSON",
                 "description": "The request body is not valid JSON",


### PR DESCRIPTION
# Strong typing

This PR is somewhat un pythonic. It adds type checking before calling the function ensuring that the arguments passed in the `PUSH`ed JSON file are correct. This means that things like

```python
# In the server file
@app.route("/someendpoint",methods=["POST"])
@fields(request)
def someendoint(somestring:string,python_typed_object:PythonType):
   pass

# In the client app
data = json.dumps({
  "somestring":"some text",
  "python_typed_object":PytonType()
})

post("<URL>/someendpoint",data=data)
```
Would be valid and yield the correct type on the server. This assumes that `PythonType`can be serialized. 

It also allows you to be certain that you receive a list of ints or a list of strings from the server front-end. If a type is not provided in the function signature then the system will just accept the type provided by the post


